### PR TITLE
Update to v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can create a debug dump using the following command:
 curl https://raw.githubusercontent.com/exablaze-oss/exanic-debug-dump/master/exanic-debug-dump.sh | bash
 ```
 
-The script will state the absolute filepath of the resulting debug dump. Upload this debug dump to the support case for further review.
+The script will state the absolute filepath of the resulting debug dump. Upload this debug dump to the Cisco TAC support case for further review.
 
 ## Supported Shells
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The ExaNIC Debug Dump is a Bash shell script that creates a gunzipped logfile co
 You can create a debug dump using the following command:
 
 ```
-curl https://raw.githubusercontent.com/exablaze-oss/exanic-debug-dump/master/exanic-debug-dump.sh | sh
+curl https://raw.githubusercontent.com/exablaze-oss/exanic-debug-dump/master/exanic-debug-dump.sh | bash
 ```
 
 The script will state the absolute filepath of the resulting debug dump. Upload this debug dump to the support case for further review.

--- a/exanic-debug-dump.sh
+++ b/exanic-debug-dump.sh
@@ -39,8 +39,8 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-product="exanic"
-product_pretty="ExaNIC"
+product="smartnic"
+product_pretty="Nexus SmartNIC"
 timestamp="$(date +%F-%HH%MM%S.%N)"
 filename="${HOSTNAME}_${product}_debug_dump_${timestamp}.log"
 filepath="${HOME}/${filename}"

--- a/exanic-debug-dump.sh
+++ b/exanic-debug-dump.sh
@@ -100,6 +100,7 @@ sudo -v
 
 cmds=(
     "date"
+    "hostname"
     "sudo lspci -vv"
     "which exanic-config"
     "sudo exanic-config -v"

--- a/exanic-debug-dump.sh
+++ b/exanic-debug-dump.sh
@@ -3,7 +3,7 @@
 help=0
 show_version=0
 compress_file=1
-version="1.0.1"
+version="1.0.2"
 
 # Borrowed from the following post: https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
 POSITIONAL=()

--- a/exanic-debug-dump.sh
+++ b/exanic-debug-dump.sh
@@ -78,7 +78,7 @@ if [ ${show_version} -eq 1 ]
 then
     echo "Cisco ${product_pretty} Debug Dump v${version}"
     echo ""
-    echo "Copyright (C) 2020 Cisco Systems, Inc."
+    echo "Copyright (C) 2021 Cisco Systems, Inc."
     echo "Cisco ${product_pretty} Debug Dump comes with ABSOLUTELY NO WARRANTY."
     echo "This is free software, and you are welcome to redistribute it"
     echo "under certain conditions. Please review the LICENSE file for"


### PR DESCRIPTION
- Add `hostname` command to debug dump.
- Update year of copyright
- Migrate from legacy Exablaze branding (ExaNIC) to Cisco branding (Nexus SmartNIC)
- Correct the command to execute debug dump such that the script is piped to Bash
- Improve instructions so that Cisco TAC support is made clear.